### PR TITLE
Update version updater

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/updater.py
+++ b/updater.py
@@ -4,26 +4,27 @@
 # Written by: * Alisson Moretto - 4w4k3
 # https://github.com/4w4k3/Insanity-Framework
 # Licensed under the BSD-3-Clause
-import urllib2
 import subprocess
+import urllib2
 
 
 def update_client_version(version):
-    """ Update the client version with the latest git version """
     with open("version.txt", "r") as vnum:
         if vnum.read() != version:
-            print("[*] Updating to latest version..")
-            subprocess.call(["git", "pull", "master"])
+            return True
         else:
-            print("[*] You already have the latest version.")
+            return False
 
 
 def main():
-    """ Main function that calls the update function """
-    update_client_version(
-        urllib2.urlopen("https://raw.githubusercontent.com/4w4k3/Insanity-Framework/master/version.txt").read()
-    )
+    version = urllib2.urlopen("https://raw.githubusercontent.com/4w4k3/Insanity-Framework/master/version.txt").read()
+    if update_client_version(version) is True:
+        subprocess.call(["git", "pull", "master"])
+        return "[*] Updated to latest version: v{}..".format(version)
+    else:
+        return "[*] You are already up to date with git origin master."
 
 
 if __name__ == '__main__':
-    main()
+    print("[*] Checking version information..")
+    print(main())

--- a/updater.py
+++ b/updater.py
@@ -4,30 +4,26 @@
 # Written by: * Alisson Moretto - 4w4k3
 # https://github.com/4w4k3/Insanity-Framework
 # Licensed under the BSD-3-Clause
-import sys
 import urllib2
-import os
+import subprocess
 
-def one():
-	response = urllib2.urlopen('https://raw.githubusercontent.com/4w4k3/Insanity-Framework/master/version.txt')
-	data = response.read()
-	fileup = open("version2.txt", 'w')
-	fileup.write(data)
-	fileup.close()
-one()
 
-def two():
-	updatechk = open('version2.txt', 'r')
-	xd2 = updatechk.read()
-	print updatechk.read()
-	version = open('version.txt', 'r')
-	xd = version.read()
-	version.close()
-	updatechk.close()
-	if xd2 != xd:
-            print '[*] New Version are available =D' + '\n' + 'Visit: https://github.com/4w4k3/Insanity-Framework'
-	else:
-            print '[*] You Already have the latest version =D'
-        os.system('sudo rm -Rf version2.txt')
+def update_client_version(version):
+    """ Update the client version with the latest git version """
+    with open("version.txt", "r") as vnum:
+        if vnum.read() != version:
+            print("[*] Updating to latest version..")
+            subprocess.call(["git", "pull", "master"])
+        else:
+            print("[*] You already have the latest version.")
 
-two()
+
+def main():
+    """ Main function that calls the update function """
+    update_client_version(
+        urllib2.urlopen("https://raw.githubusercontent.com/4w4k3/Insanity-Framework/master/version.txt").read()
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/updater.py
+++ b/updater.py
@@ -19,7 +19,7 @@ def update_client_version(version):
 def main():
     version = urllib2.urlopen("https://raw.githubusercontent.com/4w4k3/Insanity-Framework/master/version.txt").read()
     if update_client_version(version) is True:
-        subprocess.call(["git", "pull", "master"])
+        subprocess.call(["git", "pull", "origin", "master"])
         return "[*] Updated to latest version: v{}..".format(version)
     else:
         return "[*] You are already up to date with git origin master."


### PR DESCRIPTION
- Used `subprocess` in place of `os` as stated in PEP8
- Read directly from URL without the need of creating another file
- Use `git` to update the client version